### PR TITLE
Error messages for incorrect IMOD version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,8 @@ install_requires =
     starfile
     mdocfile
     pandas
+    packaging
+    rich
 include_package_data = True
 
 [options.extras_require]

--- a/yet_another_imod_wrapper/fiducials.py
+++ b/yet_another_imod_wrapper/fiducials.py
@@ -1,6 +1,7 @@
 from os import PathLike
 from pathlib import Path
 from typing import Dict, Any, List
+from rich.console import Console
 
 from .batchruntomo_config.io import read_adoc
 from .constants import TARGET_PIXEL_SIZE_FOR_ALIGNMENT, BATCHRUNTOMO_CONFIG_FIDUCIALS
@@ -9,8 +10,10 @@ from .utils import (
     prepare_imod_directory,
     run_batchruntomo,
     imod_is_installed,
+    imod_version
 )
 
+console = Console(record=True)
 
 def run_fiducial_based_alignment(
         tilt_series_file: Path,
@@ -34,8 +37,13 @@ def run_fiducial_based_alignment(
     output_directory: tilt-series directory for IMOD.
     """
     if not imod_is_installed():
-        raise RuntimeError('No IMOD installation found.')
-
+        e = 'No IMOD installation found.'
+        console.log(f'ERROR: {e}')
+        raise RuntimeError(e)
+    imod_version_correct = imod_version()
+    if not imod_version_correct[0]:
+        e = f'Ensure IMOD version 4.11 or higher is installed. Your version is {imod_version_correct[1]}'
+        console.log(f'ERROR: {e}')
     prepare_imod_directory(
         tilt_series_file=tilt_series_file,
         tilt_angles=tilt_angles,

--- a/yet_another_imod_wrapper/patch_tracking.py
+++ b/yet_another_imod_wrapper/patch_tracking.py
@@ -1,6 +1,7 @@
 from os import PathLike
 from pathlib import Path
 from typing import Dict, Any, Tuple, List
+from rich.console import Console
 
 from .batchruntomo_config.io import read_adoc
 from .constants import TARGET_PIXEL_SIZE_FOR_ALIGNMENT, BATCHRUNTOMO_CONFIG_PATCH_TRACKING
@@ -9,8 +10,10 @@ from .utils import (
     prepare_imod_directory,
     run_batchruntomo,
     imod_is_installed,
+    imod_version
 )
 
+console = Console(record=True)
 
 def run_patch_tracking_based_alignment(
         tilt_series_file: Path,
@@ -37,8 +40,13 @@ def run_patch_tracking_based_alignment(
     output_directory: tilt-series directory for IMOD.
     """
     if not imod_is_installed():
-        raise RuntimeError('No IMOD installation found.')
-
+        e = 'No IMOD installation found.'
+        console.log(f'ERROR: {e}')
+        raise RuntimeError(e)
+    imod_version_correct = imod_version()
+    if not imod_version_correct[0]:
+        e = f'Ensure IMOD version 4.11 or higher is installed. Your version is {imod_version_correct[1]}'
+        console.log(f'ERROR: {e}')
     prepare_imod_directory(
         tilt_series_file=tilt_series_file,
         tilt_angles=tilt_angles,

--- a/yet_another_imod_wrapper/utils.py
+++ b/yet_another_imod_wrapper/utils.py
@@ -4,6 +4,7 @@ import tempfile
 import shutil
 from pathlib import Path
 from typing import List, Dict
+from packaging import version
 
 import numpy as np
 
@@ -11,10 +12,17 @@ from yet_another_imod_wrapper.batchruntomo_config.io import write_adoc
 
 
 def imod_is_installed() -> bool:
-    """Check if batchruntomo is on the PATH."""
+    """Check if batchruntomo is on the PATH"""
     return shutil.which('batchruntomo') is not None
 
-
+def imod_version() -> bool:
+    """Check IMOD version is correct."""
+    imod_help_output = os.popen('imod -h').read().split()
+    find_version_idx = imod_help_output.index('Version') + 1
+    imod_version = version.parse(imod_help_output[find_version_idx])
+    correct_imod_version = imod_version >= version.parse('4.11.0')
+    return correct_imod_version, imod_version
+    
 def prepare_imod_directory(
         tilt_series_file: Path, tilt_angles: List[float], imod_directory: Path
 ):


### PR DESCRIPTION
Maybe I've checked version in a slightly strange way, but couldn't think of a better way to do it! This way it explicitly tells you the reason why it's failing: before the program just stopped and it wasn't so clear. In <v4.11 sometimes batchruntomo could be found, but it still needed to be v4.11 to run so this fixes that