### PR TITLE
Resolved ambiguity in fetching tilt axis angle from .xf file

### DIFF
--- a/src/yet_another_imod_wrapper/utils/xf.py
+++ b/src/yet_another_imod_wrapper/utils/xf.py
@@ -60,7 +60,8 @@ class XF:
         Angles are in degrees and counter-clockwise angles are positive.
         """
         cos_theta = self.transformation_matrices[:, 0, 0]
-        theta = np.rad2deg(np.arccos(cos_theta))
+        sin_theta = self.transformation_matrices[:, 1, 0]
+        theta = np.rad2deg(np.arctan2(-sin_theta / cos_theta))
         if self.initial_tilt_axis_rotation_angle is None:
             warn(
                 'no initial value provided for tilt-axis angle was \

--- a/src/yet_another_imod_wrapper/utils/xf.py
+++ b/src/yet_another_imod_wrapper/utils/xf.py
@@ -61,7 +61,7 @@ class XF:
         """
         cos_theta = self.transformation_matrices[:, 0, 0]
         sin_theta = self.transformation_matrices[:, 1, 0]
-        theta = np.rad2deg(np.arctan2(-sin_theta / cos_theta))
+        theta = np.rad2deg(np.arctan2(-sin_theta, cos_theta))
         if self.initial_tilt_axis_rotation_angle is None:
             warn(
                 'no initial value provided for tilt-axis angle was \


### PR DESCRIPTION
Using the arccosine alone to resolve the tilt axis angle from the transformation matrix is ambiguous, as a negative tilt axis angle would yield a positive value at this point.
I recently struggled with this until I found the solution in
https://github.com/scipion-em/scipion-em-reliontomo/blob/8d538ca04f8d02d7a9978e594876bbf7617dcf5f/reliontomo/convert/convert50_tomo.py#L363
(shoutout to @jormaister)